### PR TITLE
Hardcode ASG min/max capacity values

### DIFF
--- a/instances.tf
+++ b/instances.tf
@@ -33,8 +33,8 @@ resource "aws_autoscaling_group" "bastion_asg" {
     launch_configuration = "${aws_launch_configuration.bastion_lc.name}"
     load_balancers = ["${aws_elb.bastion_hosts_elb.name}"]
 
-    max_size = "${var.max_bastion_instances}"
-    min_size = "${var.min_bastion_instances}"
+    max_size = "1"
+    min_size = "1"
 
     tag {
         key = "terraform"

--- a/variables.tf
+++ b/variables.tf
@@ -29,14 +29,6 @@ variable "instance_type" {
     default = "t1.micro"
 }
 
-variable "max_bastion_instances" {
-    default = 1
-}
-
-variable "min_bastion_instances" {
-    default = 1
-}
-
 # something used to namespace the bastions
 # so multiple deployments can exist at once
 variable "stackname" { }


### PR DESCRIPTION
If you use an EC2 ASG to create more than one bastion instance behind an
ELB, when a user connects to the created ELB's DNS name, it is very likely
that they will get errors relating to SSH StrictHostKeyChecking.

This is an annoyance more than anything else, because it means changing the
known_hosts file each time the actual EC2 instance the ELB routes you to
changes from the one whose key is stored inside known_hosts.

There are a few ways around this, as I see it:
- disable StrictHostKeyCheck as an SSH option on connect, but I don't like
  this option because it increases the attack vector somewhat, although I
  concede that the SSH host key will change if the ASG drops and recreates an
  instance as part of normal ASG operation.
- add the same SSH host key to all instances raised inside the ASG, but
  this would probably be best done outside of Terraform, in a
  configuration management tool. I don't mind this way of doing things, but it
  feels a bit iffy to me.
- ensure only one instance is ever created, which is what this PR aims to
  do whilst also reducing complexity.

Rather than allude to the fact that multiple EC2 instances can be created
inside the ASG (assuming you ignore the second idea above), hardcode the
total number of instances that can be created to 1 rather than variablise
them. I appreciate variabilising things is nice, but I think it might add
more confusion than just hardcoding the value.
